### PR TITLE
Fixed CORS issues for safari requests

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,9 +23,9 @@ import { WorkerModule } from 'src/worker/worker.module';
       config.get('APP_ORIGIN'),
       'https://home-admin.herokuapp.com',
     ],
-    allowedHeaders: ['Content-Type', 'Authorization'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'Origin'],
     credentials: true,
-    methods: '*',
+    methods: [ 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS' ],
   });
   app.use(helmet());
   // app.use(csurf());


### PR DESCRIPTION
Safari was running to `Access-Control-Allow-Methods` issues with PUT requests. It wasn't allowing updating billing information and was likely blocking plenty of other requests in safari.